### PR TITLE
Remove inactivated linter exportloopref

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,15 +2,16 @@ run:
   timeout: 30m
 
 output:
-  format: line-number
+  formats:
+    - format: line-number
 
 linters:
   disable-all: false
   enable:
   - bodyclose
+  - copyloopvar
   - dogsled
   - errcheck
-  - exportloopref
   - gocognit
   - goconst
   - gocritic


### PR DESCRIPTION
```
 golangci-lint run
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats`
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
ERRO [linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports.
```