### PR TITLE
Run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/cloudfoundry/firehose_exporter
 
-go 1.22.4
+go 1.23.8
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
Goreleaser broke with:

```
go: updates to go.mod needed; to update it:
	go mod tidy
Error: Process completed with exit code 1.
```