### PR TITLE
Bump GolangCI linter action to v6

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,6 +17,6 @@ jobs:
           go-version: ">=1.22.4"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --config .golangci.yml


### PR DESCRIPTION
Seems like v3 of golangci-linter action does not work anymore (see https://github.com/cloudfoundry/firehose_exporter/actions/runs/17601920229) therefore I bumped to v6 (see https://github.com/cloudfoundry/firehose_exporter/actions/runs/18190952146) which is the last version that supports the old style of config and will create an issue to migrate the config to v2 to be able to bump to latest version of github action.