### PR TITLE
Fix go auto bump workflow

### DIFF
--- a/.github/workflows/bump-golang-and-dependencies.yml
+++ b/.github/workflows/bump-golang-and-dependencies.yml
@@ -15,7 +15,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: stable
 
       - name: Bump go directive in go.mod
         run: go mod edit -go=${{ steps.setup-go.outputs.go-version }}


### PR DESCRIPTION
Adjust to use the same config as for bosh_exporter where the workflow is working:

https://github.com/cloudfoundry/bosh_exporter/blob/6e18c6d75d62f6b09ed13f57a6b1c829ef0897c6/.github/workflows/bump-golang-and-dependencies.yml#L18